### PR TITLE
A quick Ovi compatibility fix

### DIFF
--- a/nokia2sbr.py
+++ b/nokia2sbr.py
@@ -28,6 +28,12 @@ class SMS:
       elif csv_row[1] == 'submit':
           self.direction = 'sent'
           self.other_party = csv_row[3]
+      elif 'SENT' in csv_row[1] or 'sent' in csv_row[1]:
+          self.direction = 'sent'
+          self.other_party = csv_row[3]
+      elif 'RECEIVED' in csv_row[1] or 'received' in csv_row[1]:
+          self.direction = 'received'
+          self.other_party = csv_row[2]
       self.java_time = nok_time_to_java_time(csv_row[5])
       self.body = csv_row[7]
 


### PR DESCRIPTION
Hi!

I tried to hack your utility to be Ovi Suite compatible.

This change helped me, and I think will help to your [commenter](http://frankoid.wordpress.com/2011/06/04/copy-smses-from-nokia-s60-phones-to-android-phones/#comment-22) too.

By the way an example export in Ovi format:

``` csv
"sms","READ,RECEIVED","+123456789","","","2011.06.09 07:34","","This is a received sms"
"sms","SENT,READ","+5678901234","+5678901234","","2011.06.06 11:35","","This is another sms.
But with a new line. And it is sent." 
```
